### PR TITLE
Fix skillset comment syntax

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,7 +1,7 @@
 jQuery(document).ready(function($) {
 
 
-    /*======= Skillset *=======*/
+    /*======= Skillset =======*/
     
     
     $('.level-bar-inner').css('width', '0');


### PR DESCRIPTION
## Summary
- fix the comment in `assets/js/main.js` so it reads `/*======= Skillset =======*/`

## Testing
- `grep -n Skillset assets/js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_6846725bece48322b2b6abccdf4bac9a